### PR TITLE
grammar: support specify iter with rander

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,8 +32,6 @@ require (
 	github.com/magiconair/properties v1.8.1
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/pingcap/errors v0.11.4

--- a/grammar/grammar.go
+++ b/grammar/grammar.go
@@ -1,6 +1,8 @@
 package grammar
 
 import (
+	"math/rand"
+
 	"github.com/pingcap/go-randgen/gendata"
 	"github.com/pingcap/go-randgen/grammar/sql_generator"
 	"github.com/pingcap/go-randgen/grammar/yacc_parser"
@@ -17,7 +19,26 @@ func NewIter(yy string, root string, maxRecursive int,
 	}
 
 	sqlIter, err := sql_generator.GenerateSQLRandomly(codeblocks,
-		productionMap, keyFunc, root, maxRecursive, debug)
+		productionMap, keyFunc, root, maxRecursive, nil, debug)
+	if err != nil {
+		return nil, err
+	}
+
+	return sqlIter, nil
+}
+
+// Get Iterator by yy. The same rander could guarantee the same result.
+// Note that this iterator is not thread safe
+func NewIterWithRander(yy string, root string, maxRecursive int,
+	keyFunc gendata.Keyfun, rander *rand.Rand, debug bool) (sql_generator.SQLIterator, error) {
+
+	codeblocks, _, productionMap, err := Parse(yy)
+	if err != nil {
+		return nil, err
+	}
+
+	sqlIter, err := sql_generator.GenerateSQLRandomly(codeblocks,
+		productionMap, keyFunc, root, maxRecursive, rander, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +63,7 @@ func initProductionMap(productions []*yacc_parser.Production) map[string]*yacc_p
 
 func Parse(yy string) ([]*yacc_parser.CodeBlock, []*yacc_parser.Production,
 	map[string]*yacc_parser.Production, error) {
-	reader := &yacc_parser.RuneSeq{Runes:[]rune(yy), Pos:0}
+	reader := &yacc_parser.RuneSeq{Runes: []rune(yy), Pos: 0}
 	codeblocks, productions, err := yacc_parser.Parse(yacc_parser.Tokenize(reader))
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
Support pass an rander to iter, so we can generate same result if the rander is the same.