### PR TITLE
make iterWithRander compatible with --seed param

### DIFF
--- a/cmd/go-randgen/cmd.go
+++ b/cmd/go-randgen/cmd.go
@@ -24,16 +24,12 @@ var root string
 
 var debug bool
 var skipZz bool
-var seed int
+var seed int64
 var outPath string
 
 var rootCmd = &cobra.Command{
 	Use:   "go-randgen",
 	Short: "QA tool for fuzzy test just like mysql randgen",
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		rand.Seed(int64(seed))
-		return nil
-	},
 }
 
 // init command flag
@@ -50,7 +46,7 @@ func initCmd() {
 		"print detail generate path")
 	rootCmd.PersistentFlags().BoolVar(&skipZz, "skip-zz", false,
 		"skip gen data phase, only use yy to generate random sqls")
-	rootCmd.PersistentFlags().IntVar(&seed, "seed", time.Now().Nanosecond(),
+	rootCmd.PersistentFlags().Int64Var(&seed, "seed", time.Now().UnixNano(),
 		"random number seed, default time.Now().Nanosecond()")
 	rootCmd.PersistentFlags().StringVarP(&outPath, "output", "O","output",
 		"sql output file path")
@@ -126,7 +122,8 @@ func getRandSqls(keyf gendata.Keyfun) []string {
 func getIter(keyf gendata.Keyfun) sql_generator.SQLIterator {
 	yy := loadYy()
 
-	iterator, err := grammar.NewIter(yy, root, maxRecursive, keyf, debug)
+	iterator, err := grammar.NewIterWithRander(yy, root, maxRecursive, keyf,
+		rand.New(rand.NewSource(seed)), debug)
 	if err != nil {
 		log.Fatalln("Fatal Error: " + err.Error())
 	}

--- a/cmd/go-randgen/gentest_test.go
+++ b/cmd/go-randgen/gentest_test.go
@@ -73,3 +73,29 @@ func TestUpdateSql(t *testing.T) {
 	assert.Equal(t, nil, err)
 	err = os.Remove("./upda.data.sql")
 }
+
+
+func TestSeed(t *testing.T) {
+
+	for i := 0; i < 10; i++ {
+		reInitCmd()
+		_, err := executeCommand(rootCmd, "gentest", "-Y",
+			"../../examples/toturial/embed_lua.yy", "-B", "-Q", "5", "-O",
+			"lua", "--skip-zz", "--seed", "0")
+		assert.Equal(t, nil, err)
+
+		randFilePath := "./lua.rand.sql"
+		content, err := ioutil.ReadFile(randFilePath)
+		assert.Equal(t, nil, err)
+
+		expected := `0;
+0;
+3;
+0;
+3;`
+
+		assert.Equal(t, expected, string(content))
+		err = os.Remove(randFilePath)
+		assert.Equal(t, nil, err)
+	}
+}

--- a/examples/toturial/embed_lua.yy
+++ b/examples/toturial/embed_lua.yy
@@ -1,0 +1,15 @@
+/*
+
+test embed lua
+
+used in unittest, if you change it, you should change the relational unittest in `cmd/go-randgen/gentest_test.go`
+
+*/
+
+{
+f={a=1, b=3}
+arr={0,2,3,4}
+}
+
+query:
+  {print(arr[f.a])} | {print(arr[f.b])}

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,8 @@ require (
 	github.com/magiconair/properties v1.8.1
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/pingcap/errors v0.11.4


### PR DESCRIPTION
`NewIterWithRander` make `--seed` param invalid, make it valid and add unit test about it.