### PR TITLE
Postgres support 

### DIFF
--- a/cmd/go-randgen/cmd.go
+++ b/cmd/go-randgen/cmd.go
@@ -55,7 +55,7 @@ func initCmd() {
 
 	// driver
 	rootCmd.PersistentFlags().StringVarP(&dbms, "dbms", "D", "mysql",
-		"specify the DBMS driver, defult MySQL. Supported: mysql, sqlite3.")
+		"specify the DBMS driver, defult MySQL. Supported: mysql, sqlite3, postgres.")
 
 	rootCmd.AddCommand(newExecCmd())
 	rootCmd.AddCommand(newGentestCmd())

--- a/cmd/go-randgen/cmd.go
+++ b/cmd/go-randgen/cmd.go
@@ -137,6 +137,19 @@ func getIter(keyf gendata.Keyfun) sql_generator.SQLIterator {
 }
 
 func dumpRandSqls(sqls []string) {
+	// different SQL escape characters
+	/**
+	 * MySQL: `
+	 * PostgreSQL: "
+	 */
+	if strings.EqualFold(strings.ToLower(dbms), "postgres") {
+		for i, sql := range sqls {
+			sqls[i] = strings.ReplaceAll(
+				strings.ReplaceAll(sql, "\"", "'"), // strings
+				"`", "\"")                          // column names
+		}
+	}
+
 	path := outPath + ".rand.sql"
 	err := ioutil.WriteFile(path,
 		[]byte(strings.Join(sqls, ";\n")+";"), os.ModePerm)

--- a/cmd/go-randgen/gendata.go
+++ b/cmd/go-randgen/gendata.go
@@ -8,7 +8,6 @@ import (
 	"log"
 )
 
-
 var gendataDsns []string
 
 func newGenDataCmd() *cobra.Command {
@@ -30,13 +29,13 @@ func newGenDataCmd() *cobra.Command {
 	return gendataCmd
 }
 
-
 func gendataAction(cmd *cobra.Command, args []string) {
 	ddls, _ := getDdls()
 
 	targetDbs := make([]*sql.DB, 0, len(gendataDsns))
 	for _, dsn := range gendataDsns {
-		targetDb, err := compare.OpenDBWithRetry("mysql", dsn)
+		// fixed: change "mysql" -> dbms
+		targetDb, err := compare.OpenDBWithRetry(dbms, dsn)
 		if err != nil {
 			log.Fatalf("connect dsn1 %s error %v\n", dsn, err)
 		}

--- a/cmd/go-randgen/gentest.go
+++ b/cmd/go-randgen/gentest.go
@@ -56,11 +56,10 @@ func gentestAction(cmd *cobra.Command, args []string) {
 	}
 
 	randomSqls := getRandSqls(keyf)
-
 	if breake {
 		if !skipZz {
 			err := ioutil.WriteFile(outPath+".data.sql",
-				[]byte(strings.Join(ddls, ";\n") + ";"), os.ModePerm)
+				[]byte(strings.Join(ddls, ";\n")+";"), os.ModePerm)
 			if err != nil {
 				log.Printf("write ddl in dist fail, %v\n", err)
 			}
@@ -72,8 +71,8 @@ func gentestAction(cmd *cobra.Command, args []string) {
 		allSqls = append(allSqls, ddls...)
 		allSqls = append(allSqls, randomSqls...)
 
-		err := ioutil.WriteFile(outPath + ".sql",
-			[]byte(strings.Join(allSqls, ";\n") + ";"), os.ModePerm)
+		err := ioutil.WriteFile(outPath+".sql",
+			[]byte(strings.Join(allSqls, ";\n")+";"), os.ModePerm)
 		if err != nil {
 			log.Printf("sql output error, %v\n", err)
 		}

--- a/compare/sql.go
+++ b/compare/sql.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"fmt"
 	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
 	"log"
 	"strings"

--- a/examples/postgres.yy
+++ b/examples/postgres.yy
@@ -1,0 +1,51 @@
+## AST root
+query:
+    select ;
+
+
+## _field, _table are go_randgen keywords
+select:
+    SELECT field FROM _table where ;
+
+field:
+    _field |
+    * ;
+
+## reverse the value
+/* T -> F, F -> T, NULL -> NULL */
+bi_logic:
+      |     # empty
+    NOT ;
+
+
+## numeric
+op_num:
+    + |
+    - |
+    * |
+    / ;
+
+## bitwise
+op_bit:
+    &  |
+    {print("|")} |
+    ^  |
+    << |
+    << ;
+
+
+boolean_case:
+    IS TRUE |
+    IS FALSE |
+    IS NULL ;
+
+
+## requires explicit cast
+where:
+    WHERE  bi_logic ( ( CAST( predicate AS BOOLEAN) ) boolean_case ) ;
+
+
+## _digit is a go_randgen keyword
+predicate:
+    _field op_num _digit |
+    _digit op_bit _field ;

--- a/gendata/gendata.go
+++ b/gendata/gendata.go
@@ -233,6 +233,7 @@ type Keyfun map[string]func() (string, error)
 func joinFields(fields []*fieldExec) string {
 	strBuf := bytes.Buffer{}
 
+	// decode the quotation mark
 	for i, f := range fields {
 		if i == 0 {
 			strBuf.WriteRune('`')

--- a/gendata/gendata.go
+++ b/gendata/gendata.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
+	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/go-randgen/gendata/generators"
@@ -117,8 +118,11 @@ func ByDb(db *sql.DB, dbms string) (Keyfun, error) {
 	// support different databases
 	var rows *sql.Rows
 	var err error
+	dbms = strings.ToLower(dbms)
 
-	if dbms == "sqlite3" {
+	if dbms == "postgres" {
+		rows, err = db.Query("SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname='public';")
+	} else if dbms == "sqlite3" {
 		rows, err = db.Query("SELECT name FROM sqlite_master WHERE type='table';")
 	} else if dbms == "mysql" {
 		rows, err = db.Query("show tables")
@@ -145,7 +149,11 @@ func ByDb(db *sql.DB, dbms string) (Keyfun, error) {
 	fieldExecs := make([]*fieldExec, 0)
 
 	if len(tableStmts) > 0 {
-		if dbms == "sqlite3" {
+		if dbms == "postgres" {
+			rows, err = db.Query(fmt.Sprintf("SELECT table_name, column_name, data_type \n"+
+				"FROM information_schema.columns \n"+
+				"WHERE table_name = '%s';", tableStmts[0].name))
+		} else if dbms == "sqlite3" {
 			rows, err = db.Query(fmt.Sprintf("PRAGMA table_info('%s');", tableStmts[0].name))
 		} else if dbms == "mysql" {
 			rows, err = db.Query(fmt.Sprintf("desc %s", tableStmts[0].name))
@@ -159,7 +167,9 @@ func ByDb(db *sql.DB, dbms string) (Keyfun, error) {
 
 		for rows.Next() {
 			var fieldName, fieldType string
-			if dbms == "sqlite3" {
+			if dbms == "postgres" {
+				err = rows.Scan(&sql.RawBytes{}, &fieldName, &fieldType)
+			} else if dbms == "sqlite3" {
 				err = rows.Scan(&sql.RawBytes{}, &fieldName,
 					&fieldType, &sql.RawBytes{},
 					&sql.RawBytes{}, &sql.RawBytes{})


### PR DESCRIPTION
Close: #32 

*  What is changed:
```
$ ./go-randgen gensql --help
random generate sqls by yy, parse yy keyword by user specified db, other then zz file

Usage:
  go-randgen gensql [flags]

Flags:
      --dsn string   user specified db
  -h, --help         help for gensql

Global Flags:
  -D, --dbms string     specify the DBMS driver, defult MySQL. Supported: mysql, sqlite3, postgres. (default "mysql")
```

*  How to use it:
```
./go-randgen gendata -D postgres --dsns="postgres://zhangys:zhangys@localhost:5432/test" -Y examples/functions.yy -Z my.zz

./go-randgen gensql -D postgres --dsn="postgres://zhangys:zhangys@localhost:5432/test" -Y examples/postgres.yy -Z my.zz
```